### PR TITLE
fix for cont transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3
+
+- added fix for kadena cont transaction
+
 ## 2.3.2
 
 - removed dependency on Flutter sdk from main code
@@ -7,7 +11,7 @@
 
 - updated dependencies
 - updated dart sdk to 3.0.5
-- 
+-
 ## 2.3.0
 
 - updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - updated dependencies
 - updated dart sdk to 3.0.5
--
+
 ## 2.3.0
 
 - updated dependencies

--- a/lib/models/pact_models.dart
+++ b/lib/models/pact_models.dart
@@ -54,7 +54,7 @@ class ContinuationMessage {
   int step;
   bool rollback;
   Map<String, dynamic> data;
-  String proof;
+  String? proof;
 
   ContinuationMessage({
     required this.pactId,

--- a/lib/models/pact_models.g.dart
+++ b/lib/models/pact_models.g.dart
@@ -7,23 +7,23 @@ part of 'pact_models.dart';
 // **************************************************************************
 
 ExecMessage _$ExecMessageFromJson(Map<String, dynamic> json) => ExecMessage(
-      data: json['data'] as Map<String, dynamic>,
       code: json['code'] as String,
+      data: json['data'] as Map<String, dynamic>? ?? const {},
     );
 
 Map<String, dynamic> _$ExecMessageToJson(ExecMessage instance) =>
     <String, dynamic>{
-      'data': instance.data,
       'code': instance.code,
+      'data': instance.data,
     };
 
 ContinuationMessage _$ContinuationMessageFromJson(Map<String, dynamic> json) =>
     ContinuationMessage(
       pactId: json['pactId'] as String,
-      step: json['step'] as int,
+      step: (json['step'] as num).toInt(),
       rollback: json['rollback'] as bool,
       data: json['data'] as Map<String, dynamic>,
-      proof: json['proof'] as String,
+      proof: json['proof'] as String?,
     );
 
 Map<String, dynamic> _$ContinuationMessageToJson(
@@ -98,10 +98,10 @@ CommandMetadata _$CommandMetadataFromJson(Map<String, dynamic> json) =>
     CommandMetadata(
       chainId: json['chainId'] as String,
       sender: json['sender'] as String,
-      gasLimit: json['gasLimit'] as int?,
+      gasLimit: (json['gasLimit'] as num?)?.toInt(),
       gasPrice: (json['gasPrice'] as num?)?.toDouble(),
-      ttl: json['ttl'] as int?,
-      creationTime: json['creationTime'] as int?,
+      ttl: (json['ttl'] as num?)?.toInt(),
+      creationTime: (json['creationTime'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$CommandMetadataToJson(CommandMetadata instance) =>
@@ -172,9 +172,9 @@ PactResultMetadata _$PactResultMetadataFromJson(Map<String, dynamic> json) =>
     PactResultMetadata(
       publicMeta:
           CommandMetadata.fromJson(json['publicMeta'] as Map<String, dynamic>),
-      blockTime: json['blockTime'] as int,
+      blockTime: (json['blockTime'] as num).toInt(),
       prevBlockHash: json['prevBlockHash'] as String,
-      blockHeight: json['blockHeight'] as int,
+      blockHeight: (json['blockHeight'] as num).toInt(),
     );
 
 Map<String, dynamic> _$PactResultMetadataToJson(PactResultMetadata instance) =>
@@ -186,7 +186,7 @@ Map<String, dynamic> _$PactResultMetadataToJson(PactResultMetadata instance) =>
     };
 
 PactResponse _$PactResponseFromJson(Map<String, dynamic> json) => PactResponse(
-      gas: json['gas'] as int,
+      gas: (json['gas'] as num).toInt(),
       result:
           PactResult<dynamic>.fromJson(json['result'] as Map<String, dynamic>),
       reqKey: json['reqKey'] as String,

--- a/lib/models/sign_models.g.dart
+++ b/lib/models/sign_models.g.dart
@@ -24,10 +24,10 @@ SignRequest _$SignRequestFromJson(Map<String, dynamic> json) => SignRequest(
       sender: json['sender'] as String,
       networkId: json['networkId'] as String,
       chainId: json['chainId'] as String,
-      gasLimit: json['gasLimit'] as int?,
+      gasLimit: (json['gasLimit'] as num?)?.toInt(),
       gasPrice: (json['gasPrice'] as num?)?.toDouble(),
       signingPubKey: json['signingPubKey'] as String?,
-      ttl: json['ttl'] as int?,
+      ttl: (json['ttl'] as num?)?.toInt(),
       caps: (json['caps'] as List<dynamic>?)
           ?.map((e) => DappCapp.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kadena_dart_sdk
 description: A dart package for interacting with the Kadena blockchain.
-version: 2.3.2
+version: 2.3.3
 repository: https://github.com/Eucalyptus-Labs/KadenaDartSdk
 
 environment:


### PR DESCRIPTION
# Description

This is an update to fix cont transactions for Kadena. The parseQuicksignRequest returns null for cont but the PactCommandPayload model declares cont as a non-nullable

Resolves # (issue)

## How Has This Been Tested?

* Tested on a Kadena dapp [](https://atriumnfts.app.runonflux.io/) that implements cont transactions
* Connect with a wallet app using WC
* Look for any of the pitbull nft available and try to make a purchase. It should be successfully if you have enough kda.

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update