### PR TITLE
fix for cont transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3
+
+- added fix for kadena cont transaction
+
 ## 2.3.2
 
 - removed dependency on Flutter sdk from main code
@@ -7,7 +11,7 @@
 
 - updated dependencies
 - updated dart sdk to 3.0.5
-- 
+-
 ## 2.3.0
 
 - updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - updated dependencies
 - updated dart sdk to 3.0.5
--
+
 ## 2.3.0
 
 - updated dependencies

--- a/lib/models/pact_models.dart
+++ b/lib/models/pact_models.dart
@@ -54,7 +54,7 @@ class ContinuationMessage {
   int step;
   bool rollback;
   Map<String, dynamic> data;
-  String proof;
+  String? proof;
 
   ContinuationMessage({
     required this.pactId,

--- a/lib/models/pact_models.dart
+++ b/lib/models/pact_models.dart
@@ -29,7 +29,8 @@ class ExecMessage {
     this.data = const {},
   });
 
-  factory ExecMessage.fromJson(Map<String, dynamic> json) => _$ExecMessageFromJson(json);
+  factory ExecMessage.fromJson(Map<String, dynamic> json) =>
+      _$ExecMessageFromJson(json);
 
   Map<String, dynamic> toJson() => _$ExecMessageToJson(this);
 
@@ -40,12 +41,16 @@ class ExecMessage {
 
   @override
   bool operator ==(Object other) {
-    return other is ExecMessage && other.code == code && mapEquals(other.data, data);
+    return other is ExecMessage &&
+        other.code == code &&
+        mapEquals(other.data, data);
   }
 
   @override
   int get hashCode =>
-      code.hashCode ^ data.keys.fold(0, (i, e) => i + e.hashCode) ^ data.values.fold(0, (i, e) => i + e.hashCode);
+      code.hashCode ^
+      data.keys.fold(0, (i, e) => i + e.hashCode) ^
+      data.values.fold(0, (i, e) => i + e.hashCode);
 }
 
 @JsonSerializable()
@@ -64,7 +69,8 @@ class ContinuationMessage {
     required this.proof,
   });
 
-  factory ContinuationMessage.fromJson(Map<String, dynamic> json) => _$ContinuationMessageFromJson(json);
+  factory ContinuationMessage.fromJson(Map<String, dynamic> json) =>
+      _$ContinuationMessageFromJson(json);
 
   Map<String, dynamic> toJson() => _$ContinuationMessageToJson(this);
 
@@ -106,7 +112,8 @@ class CommandPayload {
     this.cont,
   });
 
-  factory CommandPayload.fromJson(Map<String, dynamic> json) => _$CommandPayloadFromJson(json);
+  factory CommandPayload.fromJson(Map<String, dynamic> json) =>
+      _$CommandPayloadFromJson(json);
 
   Map<String, dynamic> toJson() => _$CommandPayloadToJson(this);
 
@@ -134,7 +141,8 @@ class Capability {
     this.args = const [],
   });
 
-  factory Capability.fromJson(Map<String, dynamic> json) => _$CapabilityFromJson(json);
+  factory Capability.fromJson(Map<String, dynamic> json) =>
+      _$CapabilityFromJson(json);
 
   Map<String, dynamic> toJson() => _$CapabilityToJson(this);
 
@@ -145,7 +153,9 @@ class Capability {
 
   @override
   bool operator ==(Object other) {
-    return other is Capability && other.name == name && listEquals(other.args, args);
+    return other is Capability &&
+        other.name == name &&
+        listEquals(other.args, args);
   }
 
   @override
@@ -162,7 +172,8 @@ class SignerCapabilities {
     this.clist,
   });
 
-  factory SignerCapabilities.fromJson(Map<String, dynamic> json) => _$SignerCapabilitiesFromJson(json);
+  factory SignerCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$SignerCapabilitiesFromJson(json);
 
   Map<String, dynamic> toJson() => _$SignerCapabilitiesToJson(this);
 
@@ -173,11 +184,14 @@ class SignerCapabilities {
 
   @override
   bool operator ==(Object other) {
-    return other is SignerCapabilities && other.pubKey == pubKey && listEquals(other.clist, clist);
+    return other is SignerCapabilities &&
+        other.pubKey == pubKey &&
+        listEquals(other.clist, clist);
   }
 
   @override
-  int get hashCode => pubKey.hashCode ^ clist!.fold(0, (i, e) => i + e.hashCode);
+  int get hashCode =>
+      pubKey.hashCode ^ clist!.fold(0, (i, e) => i + e.hashCode);
 }
 
 @JsonSerializable()
@@ -214,7 +228,8 @@ class CommandMetadata {
         ttl = ttl ?? 600,
         creationTime = creationTime ?? Utils.getCreationTime();
 
-  factory CommandMetadata.fromJson(Map<String, dynamic> json) => _$CommandMetadataFromJson(json);
+  factory CommandMetadata.fromJson(Map<String, dynamic> json) =>
+      _$CommandMetadataFromJson(json);
 
   Map<String, dynamic> toJson() => _$CommandMetadataToJson(this);
 
@@ -236,7 +251,12 @@ class CommandMetadata {
 
   @override
   int get hashCode =>
-      chainId.hashCode ^ gasLimit.hashCode ^ gasPrice.hashCode ^ sender.hashCode ^ ttl.hashCode ^ creationTime.hashCode;
+      chainId.hashCode ^
+      gasLimit.hashCode ^
+      gasPrice.hashCode ^
+      sender.hashCode ^
+      ttl.hashCode ^
+      creationTime.hashCode;
 }
 
 @JsonSerializable()
@@ -255,7 +275,8 @@ class PactCommandPayload {
     String? nonce,
   }) : nonce = nonce ?? DateTime.now().toIso8601String();
 
-  factory PactCommandPayload.fromJson(Map<String, dynamic> json) => _$PactCommandPayloadFromJson(json);
+  factory PactCommandPayload.fromJson(Map<String, dynamic> json) =>
+      _$PactCommandPayloadFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactCommandPayloadToJson(this);
 
@@ -323,7 +344,8 @@ class PactCommand {
     required this.sigs,
   });
 
-  factory PactCommand.fromJson(Map<String, dynamic> json) => _$PactCommandFromJson(json);
+  factory PactCommand.fromJson(Map<String, dynamic> json) =>
+      _$PactCommandFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactCommandToJson(this);
 
@@ -334,11 +356,15 @@ class PactCommand {
 
   @override
   bool operator ==(Object other) {
-    return other is PactCommand && other.cmd == cmd && other.hash == hash && listEquals(other.sigs, sigs);
+    return other is PactCommand &&
+        other.cmd == cmd &&
+        other.hash == hash &&
+        listEquals(other.sigs, sigs);
   }
 
   @override
-  int get hashCode => cmd.hashCode ^ hash.hashCode ^ sigs.fold(0, (i, e) => i + e.hashCode);
+  int get hashCode =>
+      cmd.hashCode ^ hash.hashCode ^ sigs.fold(0, (i, e) => i + e.hashCode);
 }
 
 /// GENERIC PACT ENDPOINT OBJECTS
@@ -364,7 +390,8 @@ class PactResultMetadata {
     required this.blockHeight,
   });
 
-  factory PactResultMetadata.fromJson(Map<String, dynamic> json) => _$PactResultMetadataFromJson(json);
+  factory PactResultMetadata.fromJson(Map<String, dynamic> json) =>
+      _$PactResultMetadataFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactResultMetadataToJson(this);
 
@@ -394,7 +421,8 @@ class PactResponse {
     required this.txId,
   });
 
-  factory PactResponse.fromJson(Map<String, dynamic> json) => _$PactResponseFromJson(json);
+  factory PactResponse.fromJson(Map<String, dynamic> json) =>
+      _$PactResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactResponseToJson(this);
 
@@ -418,7 +446,8 @@ class PactEvent {
     required this.moduleHash,
   });
 
-  factory PactEvent.fromJson(Map<String, dynamic> json) => _$PactEventFromJson(json);
+  factory PactEvent.fromJson(Map<String, dynamic> json) =>
+      _$PactEventFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactEventToJson(this);
 
@@ -440,7 +469,8 @@ class PactResult<T> {
     this.error,
   });
 
-  factory PactResult.fromJson(Map<String, dynamic> json) => _$PactResultFromJson(json, (object) => object as T);
+  factory PactResult.fromJson(Map<String, dynamic> json) =>
+      _$PactResultFromJson(json, (object) => object as T);
 
   Map<String, dynamic> toJson() => _$PactResultToJson(this, (t) => t);
 
@@ -458,7 +488,8 @@ class PactApiError {
     required this.error,
   });
 
-  factory PactApiError.fromJson(Map<String, dynamic> json) => _$PactApiErrorFromJson(json);
+  factory PactApiError.fromJson(Map<String, dynamic> json) =>
+      _$PactApiErrorFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactApiErrorToJson(this);
 
@@ -478,7 +509,8 @@ class PactSendRequest {
     required this.cmds,
   });
 
-  factory PactSendRequest.fromJson(Map<String, dynamic> json) => _$PactSendRequestFromJson(json);
+  factory PactSendRequest.fromJson(Map<String, dynamic> json) =>
+      _$PactSendRequestFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactSendRequestToJson(this);
 
@@ -496,7 +528,8 @@ class PactSendResponse {
     required this.requestKeys,
   });
 
-  factory PactSendResponse.fromJson(Map<String, dynamic> json) => _$PactSendResponseFromJson(json);
+  factory PactSendResponse.fromJson(Map<String, dynamic> json) =>
+      _$PactSendResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactSendResponseToJson(this);
 
@@ -516,7 +549,8 @@ class PactListenRequest {
     required this.listen,
   });
 
-  factory PactListenRequest.fromJson(Map<String, dynamic> json) => _$PactListenRequestFromJson(json);
+  factory PactListenRequest.fromJson(Map<String, dynamic> json) =>
+      _$PactListenRequestFromJson(json);
 
   Map<String, dynamic> toJson() => _$PactListenRequestToJson(this);
 

--- a/lib/models/pact_models.g.dart
+++ b/lib/models/pact_models.g.dart
@@ -7,23 +7,23 @@ part of 'pact_models.dart';
 // **************************************************************************
 
 ExecMessage _$ExecMessageFromJson(Map<String, dynamic> json) => ExecMessage(
-      data: json['data'] as Map<String, dynamic>,
       code: json['code'] as String,
+      data: json['data'] as Map<String, dynamic>? ?? const {},
     );
 
 Map<String, dynamic> _$ExecMessageToJson(ExecMessage instance) =>
     <String, dynamic>{
-      'data': instance.data,
       'code': instance.code,
+      'data': instance.data,
     };
 
 ContinuationMessage _$ContinuationMessageFromJson(Map<String, dynamic> json) =>
     ContinuationMessage(
       pactId: json['pactId'] as String,
-      step: json['step'] as int,
+      step: (json['step'] as num).toInt(),
       rollback: json['rollback'] as bool,
       data: json['data'] as Map<String, dynamic>,
-      proof: json['proof'] as String,
+      proof: json['proof'] as String?,
     );
 
 Map<String, dynamic> _$ContinuationMessageToJson(
@@ -98,10 +98,10 @@ CommandMetadata _$CommandMetadataFromJson(Map<String, dynamic> json) =>
     CommandMetadata(
       chainId: json['chainId'] as String,
       sender: json['sender'] as String,
-      gasLimit: json['gasLimit'] as int?,
+      gasLimit: (json['gasLimit'] as num?)?.toInt(),
       gasPrice: (json['gasPrice'] as num?)?.toDouble(),
-      ttl: json['ttl'] as int?,
-      creationTime: json['creationTime'] as int?,
+      ttl: (json['ttl'] as num?)?.toInt(),
+      creationTime: (json['creationTime'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$CommandMetadataToJson(CommandMetadata instance) =>
@@ -172,9 +172,9 @@ PactResultMetadata _$PactResultMetadataFromJson(Map<String, dynamic> json) =>
     PactResultMetadata(
       publicMeta:
           CommandMetadata.fromJson(json['publicMeta'] as Map<String, dynamic>),
-      blockTime: json['blockTime'] as int,
+      blockTime: (json['blockTime'] as num).toInt(),
       prevBlockHash: json['prevBlockHash'] as String,
-      blockHeight: json['blockHeight'] as int,
+      blockHeight: (json['blockHeight'] as num).toInt(),
     );
 
 Map<String, dynamic> _$PactResultMetadataToJson(PactResultMetadata instance) =>
@@ -186,7 +186,7 @@ Map<String, dynamic> _$PactResultMetadataToJson(PactResultMetadata instance) =>
     };
 
 PactResponse _$PactResponseFromJson(Map<String, dynamic> json) => PactResponse(
-      gas: json['gas'] as int,
+      gas: (json['gas'] as num).toInt(),
       result:
           PactResult<dynamic>.fromJson(json['result'] as Map<String, dynamic>),
       reqKey: json['reqKey'] as String,

--- a/lib/models/sign_models.g.dart
+++ b/lib/models/sign_models.g.dart
@@ -24,10 +24,10 @@ SignRequest _$SignRequestFromJson(Map<String, dynamic> json) => SignRequest(
       sender: json['sender'] as String,
       networkId: json['networkId'] as String,
       chainId: json['chainId'] as String,
-      gasLimit: json['gasLimit'] as int?,
+      gasLimit: (json['gasLimit'] as num?)?.toInt(),
       gasPrice: (json['gasPrice'] as num?)?.toDouble(),
       signingPubKey: json['signingPubKey'] as String?,
-      ttl: json['ttl'] as int?,
+      ttl: (json['ttl'] as num?)?.toInt(),
       caps: (json['caps'] as List<dynamic>?)
           ?.map((e) => DappCapp.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/lib/signing_api/signing_api.dart
+++ b/lib/signing_api/signing_api.dart
@@ -55,7 +55,9 @@ ${request.toString()}''',
       signers: [
         SignerCapabilities(
           pubKey: request.signingPubKey ?? signingPubKey,
-          clist: request.caps == null || request.caps!.isEmpty ? null : request.caps?.map((e) => e.cap).toList(),
+          clist: request.caps == null || request.caps!.isEmpty
+              ? null
+              : request.caps?.map((e) => e.cap).toList(),
         ),
       ],
       meta: CommandMetadata(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kadena_dart_sdk
 description: A dart package for interacting with the Kadena blockchain.
-version: 2.3.2
+version: 2.3.3
 repository: https://github.com/Eucalyptus-Labs/KadenaDartSdk
 
 environment:


### PR DESCRIPTION
# Description

This is an update to fix cont transactions for Kadena. The parseQuicksignRequest returns null for cont but the PactCommandPayload model declares cont as a non-nullable

Resolves # (issue)

## How Has This Been Tested?

* Tested on a Kadena dapp [](https://atriumnfts.app.runonflux.io/) that implements cont transactions
* Connect with a wallet app using WC
* Look for any of the pitbull nft available and try to make a purchase. It should be successfully if you have enough kda.

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update